### PR TITLE
Fontstack with @font-face

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -67,9 +67,6 @@
 	<link rel="stylesheet" href="{{StaticUrlPrefix}}/css/easymde.css?v={{MD5 AppVer}}">
 {{end}}
 	<link rel="stylesheet" href="{{StaticUrlPrefix}}/css/index.css?v={{MD5 AppVer}}">
-	<script>
-		if (navigator.userAgent.match('Windows')) { document.documentElement.style.setProperty('--fonts-system-ui', 'Segoe UI'); }
-	</script>
 	<noscript>
 		<style>
 			.dropdown:hover > .menu { display: block; }

--- a/web_src/less/_base.less
+++ b/web_src/less/_base.less
@@ -1,11 +1,10 @@
 :root {
   /* documented customizable variables */
-  --fonts-proportional: var(--fonts-system-ui), "Roboto", "Helvetica Neue", "Arial", "Noto Sans", "Liberation Sans";
+  --fonts-proportional: system-ui, -apple-system, "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans", "Liberation Sans", sans-serif;
   --fonts-monospace: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
-  --fonts-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji Mozilla";
+  --fonts-emoji: system-emoji;
   /* other variables */
-  --fonts-system-ui: system-ui, -apple-system; // will be replaced with "Segoe UI" if user agent is Windows
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), sans-serif;
+  --fonts-regular: var(--fonts-emoji), var(--fonts-proportional);
   --border-radius: .28571429rem;
   --opacity-disabled: .55;
   --color-primary: #4183c4;
@@ -116,42 +115,10 @@
   --checkbox-mask-indeterminate: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path></svg>');
 }
 
-:root:lang(ja) {
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Source Han Sans JP", "Noto Sans CJK JP", "Droid Sans Japanese", "Meiryo", "MS PGothic", sans-serif;
-}
-
-:root:lang(zh-CN) {
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), "PingFang SC", "Hiragino Sans GB", "Source Han Sans CN", "Source Han Sans SC", "Noto Sans CJK SC", "Microsoft YaHei", "Heiti SC", "SimHei", sans-serif;
-}
-
-:root:lang(zh-TW) {
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), "PingFang TC", "Hiragino Sans TC", "Source Han Sans TW", "Source Han Sans TC", "Noto Sans CJK TC", "Microsoft JhengHei", "Heiti TC", "PMingLiU", sans-serif;
-}
-
-:root:lang(zh-HK) {
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), "PingFang HK", "Hiragino Sans TC", "Source Han Sans HK", "Source Han Sans TC", "Noto Sans CJK TC", "Microsoft JhengHei", "Heiti TC", "PMingLiU_HKSCS", "PMingLiU", sans-serif;
-}
-
-:root:lang(ko) {
-  --fonts-regular: var(--fonts-proportional), var(--fonts-emoji), "Apple SD Gothic Neo", "NanumBarunGothic", "Malgun Gothic", "Gulim", "Dotum", "Nanum Gothic", "Source Han Sans KR", "Noto Sans CJK KR", sans-serif;
-}
-
 @font-face {
-  font-family: "Yu Gothic";
-  src: local("Yu Gothic Regular"), local("Yu Gothic Medium");
-  font-weight: 300;
-}
-
-@font-face {
-  font-family: "Yu Gothic";
-  src: local("Yu Gothic Medium");
-  font-weight: 400;
-}
-
-@font-face {
-  font-family: "Yu Gothic";
-  src: local("Yu Gothic Bold");
-  font-weight: 700;
+  font-family: system-emoji;
+  src: local("Apple Color Emoji"), local("Segoe UI Emoji"), local("Noto Color Emoji"), local("Twemoji Mozilla");
+  unicode-range: ~"U+2310-329F, U+FE0?, U+1F000-1FAFF";
 }
 
 textarea {

--- a/web_src/less/_font_i18n.less
+++ b/web_src/less/_font_i18n.less
@@ -1,0 +1,108 @@
+/* font i18n */
+:root {
+  /* customizable localized variables */
+  :lang(ja) {
+    --fonts-regular: var(--fonts-emoji), system-ui-ja, var(--fonts-proportional);
+  }
+  :lang(zh-CN) {
+    --fonts-regular: var(--fonts-emoji), system-ui-zh-cn, var(--fonts-proportional);
+  }
+  :lang(zh-TW) {
+    --fonts-regular: var(--fonts-emoji), system-ui-zh-tw, var(--fonts-proportional);
+  }
+  :lang(zh-HK) {
+    --fonts-regular: var(--fonts-emoji), system-ui-zh-hk, var(--fonts-proportional);
+  }
+  :lang(ko) {
+    --fonts-regular: var(--fonts-emoji), system-ui-ko, var(--fonts-proportional);
+  }
+}
+
+[lang] {
+  font-family: var(--fonts-regular);
+}
+
+each(@fonts, {
+  @weights: .gen-weights-all(@value);
+  @locale: replace(@key, "@", "-");
+  .font-face-cjk(~"system-ui@{locale}", @weights[@light], 300);
+  .font-face-cjk(~"system-ui@{locale}", @weights[@regular], 400);
+  .font-face-cjk(~"system-ui@{locale}", @weights[@medium], 500);
+  .font-face-cjk(~"system-ui@{locale}", @weights[@bold], 700);
+});
+
+@fonts: {
+  @ja:
+    "HiraginoSans-:{W2,W4,W5,W6}", "Hiragino Kaku Gothic ProN :{W3,W6}",
+    .shs("JP")[], .shs("J")[], .noto("JP")[], .shs("")[],
+    /* https://acetaminophen.hatenablog.com/entry/2016/02/15/225009 */
+    "Yu Gothic :{Regular,Medium,Medium,Bold}", "YuGothic :{Regular,Medium,Medium,Bold}",
+    "Droid Sans Japanese:{}", "Meiryo:{, Bold}", "MS PGothic:{}";
+  @zh-cn:
+    .pingfang("SC")[],
+    .shs("CN")[], .shs("SC")[], .noto("SC")[],
+    "HiraginoSansGB-:{W3,W6}", "Hiragino Sans GB :{W3,W6}",
+    "Microsoft YaHei:{ Light,, Bold}", "Heiti SC :{Light,Medium}", "SimHei:{}";
+  @zh-tw:
+    .pingfang("TC")[],
+    .shs("TW")[], .shs("TC")[], .noto("TC")[],
+    "HiraginoSansTC-:{W3,W6}", "Hiragino Sans TC :{W3,W6}",
+    "Microsoft JhengHei:{ Light,, Bold}", "Heiti TC :{Light,Medium}", "PMingLiU:{}";
+  @zh-hk:
+    .pingfang("HK")[],
+    .shs("HK")[], .shs("HC")[], .noto("HK")[], .shs("TC")[], .noto("TC")[],
+    "Microsoft JhengHei:{ Light,, Bold}", "Heiti TC :{Light,Medium}", "PMingLiU_HKSCS:{}", "PMingLiU:{}";
+  @ko:
+    "AppleSDGothicNeo-:{Light,Regular,Medium,Semibold}",
+    .shs("KR")[], .shs("K")[], .noto("KR")[],
+    "NanumBarunGothic:{ Light,, Bold}",
+    "Malgun Gothic:{ Semilight,, Bold}", "Nanum Gothic:{, Bold}", "Dotum:{}";
+}
+
+.noto(@suffix) { @value: "Noto Sans CJK @{suffix} ", "NotoSansCJK@{suffix}-"; }
+.shs(@suffix) { @value: replace("Source Han Sans @{suffix} ", "  ", " "), "SourceHanSans@{suffix}-"; }
+.pingfang(@suffix) { @value: "PingFang@{suffix}-:{Light,Regular,Medium,Semibold}"; }
+.font-face-cjk(@family, @src, @weight) {
+  @font-face {
+    font-family: @family;
+    src: @src;
+    font-weight: @weight;
+    unicode-range: ~"U+11??, U+2E80-4DBF, U+AC00-D7FF, U+4E00-9FFF, U+FF00-FFEF, U+1F2??";
+  }
+}
+
+.gen-weights(@family) when (isstring(@family)) {
+  @family-str: replace(@family, ":\{.*\}$", "");
+  // apply standard style names if none is given
+  // should the font have no styles, use :{}, as in "SimHei:{}"
+  @weights-str: if(@family = @family-str, "Light,Regular,Medium,Bold", replace(@family, ".*:\{(.*)\}$", "$1"));
+  @lightest: replace(@weights-str, ",.*", "");
+  @boldest: replace(@weights-str, ".*,", "");
+  @2ndboldest: replace(@weights-str, "(?:.*,|)([^,]*),.*$", "$1");
+  @2ndlightest: if(@2ndboldest = @lightest, @lightest, replace(@weights-str, "^.*?,([^,]*).*", "$1"));
+
+  @light: local("@{family-str}@{lightest}");
+  @regular: local("@{family-str}@{2ndlightest}");
+  @medium: local("@{family-str}@{2ndboldest}");
+  @bold: local("@{family-str}@{boldest}");
+}
+.gen-weights(@family) when not (isstring(@family)) {
+  .gen-weights-all(@family);
+}
+.gen-weights(@family, @last) {
+  @this: .gen-weights(@family);
+
+  @light: @last[@light], @this[@light];
+  @regular: @last[@regular], @this[@regular];
+  @medium: @last[@medium], @this[@medium];
+  @bold: @last[@bold], @this[@bold];
+}
+.gen-weights-all(@family) when not (isstring(@family)) {
+  .gen-weights-all(@family, length(@family));
+}
+.gen-weights-all(@family, 1) when not (isstring(@family)) {
+  .gen-weights(extract(@family, 1));
+}
+.gen-weights-all(@family, @ctr) when not (isstring(@family)) and (@ctr > 1) and (@ctr <= length(@family)) {
+  .gen-weights(extract(@family, @ctr), .gen-weights-all(@family, @ctr - 1));
+}

--- a/web_src/less/index.less
+++ b/web_src/less/index.less
@@ -12,6 +12,7 @@
 
 @import "_svg";
 @import "_tribute";
+@import "_font_i18n";
 @import "_base";
 @import "_markdown";
 @import "_home";


### PR DESCRIPTION
Since there have been so many issues to address with CJK fonts after go-gitea#13204, I decided to try out `unicode-range` as mentioned go-gitea#13784. After doing trial and error for multiple days, the solution seems to work fine on all the platforms I have tested.

This approach attempts to minimize the size of the generated CSS while keeping the Less source code largely readable, so modifications could be easily made when things change (could happen in the future when OSes bundles new fonts, for example).

This solution tries to make the look and feel consistent and nuanced (in terms of weight matching) and does further changes to the localized font stacks for optimal results across platforms. For example, on a non-post-OS X 10.11 machine with Source/Noto fonts installed, they are now preferred for Chinese and Japanese as they would match perfectly in weight, and thus win over other candidates in the stack.

The mixed usage of PostScript names and full names in the stack is done as suggested by W3C. For example, since PingFang is most probably macOS only, only PS name is included.

The code points for CJK does not include compatibility glyphs as they are very rarely used and, while I did try to include them, all browsers seemed to invalidate the entire rule, although it clearly matched what is specified in MDN and W3C, but that's where the compromises end. The new font stacks are more sound and less intrusive (no moving-sans-serif-around anymore), yet still generates less CSS than the former solution with preprocessed global replacements. The only real addition is to properly override `<html lang>` when `<tag lang>` is defined (with `[lang]` rule), an issue introduced in go-gitea#13204 as browsers do not override `:root` variables with `:root :lang()` variables of the same names.

As before, further testing is highly welcome, but I would consider this more mature than the previous solution (which already had `@font-face` rules for Japanese).