### PR TITLE
Fix cache/path issue with npm 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,8 @@ coverage.all
 
 # Frontend
 .npmrc
-/node_modules
+.npm-cache
+node_modules
 /yarn.lock
 /public/js
 /public/serviceworker.js
@@ -84,6 +85,7 @@ coverage.all
 /public/fonts
 /public/img/webpack
 /web_src/fomantic/node_modules
+/web_src/fomantic/package-lock.json
 /web_src/fomantic/semantic.json
 /web_src/fomantic/build/*
 !/web_src/fomantic/build/semantic.js
@@ -98,7 +100,6 @@ coverage.all
 !/web_src/fomantic/build/themes/default/assets/fonts/outline-icons.woff2
 /VERSION
 /.air
-/.npm-cache
 
 # Snapcraft
 snap/.snapcraft/

--- a/web_src/fomantic/package.json
+++ b/web_src/fomantic/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "fomantic-ui": "^2.8.7"
+  }
+}


### PR DESCRIPTION
Tested on Windows 10 (MSYS2), Ubuntu 18.04 amd64 (VMware Fusion), Fedora 33, Manjaro 18.1, with both npm 6 and npm 7.

The only awkward result was on the Ubuntu VM, where installing Fomantic is blazing fast with npm 6 but takes quite some time (more than 40 seconds) to complete with npm 7, probably due to VM-specific performance issue with filesystem. Webpack doesn't suffer from this (10 seconds). Symlinking and even moving `.npm-cache` didn't help. More testing is welcome.

Note that npm 7 really requires **both** `package.json` and `package-lock.json` for cache to work *at all*. This wasn't the case for npm 6. For this reason, the `--no-package-lock` switch is dropped for Fomantic. `package-lock.json` will be deleted and regenerated each time `make npm-cache` runs while being ignored by Git at all time.

Other fixes involve working with the npm 7 path issue (using `echo` for `.npmrc` manipulation as `npm config` resolves relative paths to absolute paths, making the tarball not portable), as well as miscellaneous fixes (using `$OLDPWD` instead of `../../` as latter is not portable if `$(FOMANTIC_PATH)` is moved; removing the leading `/` from `.npm-cache` and `node_modules` in `.gitignore` as they should be ignored at any directory level)